### PR TITLE
Bump library versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,9 +181,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -300,8 +300,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "rand 0.9.2",
+ "siphasher",
+]
+
+[[package]]
 name = "fastmssql_core"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "ahash",
  "bb8",
@@ -312,6 +324,7 @@ dependencies = [
  "parking_lot",
  "pyo3",
  "pyo3-async-runtimes",
+ "quinn-proto",
  "reqwest",
  "serde_json",
  "serde_urlencoded",
@@ -748,9 +761,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -764,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1028,12 +1047,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
+ "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
@@ -1215,9 +1235,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
@@ -1246,6 +1266,7 @@ checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.9",
  "subtle",
@@ -1498,6 +1519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,9 +1597,9 @@ checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
@@ -1678,9 +1705,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -1853,9 +1880,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastmssql_core"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2024"
 
 [lib]
@@ -29,19 +29,20 @@ opt-level = 2
 [dependencies]
 pyo3 = { version = "0.28.0", features = ["extension-module", "abi3-py311"] }
 pyo3-async-runtimes = { version = "0.28.0", features = ["tokio", "tokio-runtime"] }
-tokio = { version = "1.49.0", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 tiberius = { version = "0.12.3", features = ["chrono", "rustls"], default-features = false }
 tokio-util = { version = "0.7.18", features = ["compat"] }
 bb8 = "0.9.1"
 bb8-tiberius = "0.16"
-chrono = { version = "0.4.43" }
-uuid = { version = "1.21.0" }
+chrono = { version = "0.4.44" }
+uuid = { version = "1.22.0" }
 ahash = "0.8.12"              # Faster hashing algorithm (used in optimized_types.rs)
 smallvec = "1.15.1"          # Stack-allocated vectors for small collections
 parking_lot = "0.12.5"       # Faster mutex/RwLock implementation than std::sync
 mimalloc = { version = "0.1.48", default-features = false } # Microsoft's fast memory allocator
 slab = "0.4.12"              # Pinned sub-dependency due to CVE-2025-55159
 bytes = "1.11.1"             # Pinned sub-dependency due to CVE-2026-25541
+quinn-proto = "0.11.14"      # Pinned sub-dependency due to CVE-2026-31812
 
 # Azure authentication dependencies
 reqwest = { version = "0.13.2", features = ["json", "rustls"], default-features = false }
@@ -50,4 +51,4 @@ serde_urlencoded = "0.7.1"
 
 
 [dev-dependencies]
-tempfile = "3.25.0"
+tempfile = "3.27.0"

--- a/README.md
+++ b/README.md
@@ -16,25 +16,6 @@ Great for data ingestion, bulk inserts, and large-scale query workloads.
 
 [![Rust Backend](https://img.shields.io/badge/backend-rust-orange)](https://github.com/Rivendael/pymssql-rs)
 
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-- [Features](#features)
-- [Key API methods](#key-api-methods)
-- [Installation](#installation)
-- [Quick start](#quick-start)
-- [Explicit Connection Management](#explicit-connection-management)
-- [Usage](#usage)
-- [Performance tips](#performance-tips)
-- [Examples & benchmarks](#examples--benchmarks)
-- [Troubleshooting](#troubleshooting)
-- [Contributing](#contributing)
-- [License](#license)
-- [Third‑party attributions](#third%E2%80%91party-attributions)
-- [Acknowledgments](#acknowledgments)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 ## Features
 
 - High performance: optimized for very high RPS and low overhead

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "fastmssql"
-version = "0.6.6"
+version = "0.6.7"
 
 description = "A high-performance async Python library for Microsoft SQL Server built on Rust for heavy workloads and low latency."
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "fastmssql"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
This pull request updates the `fastmssql_core` crate and its Python package to version 0.6.7, and includes dependency upgrades for improved compatibility and security. Additionally, it removes the auto-generated table of contents from the `README.md` to streamline documentation.

Dependency updates and security improvements:

* Upgraded `tokio` to version 1.50.0, `chrono` to 0.4.44, and `uuid` to 1.22.0 for better compatibility and bug fixes.
* Added and updated pinned dependencies (`quinn-proto`, `slab`, `bytes`) to address recent CVEs and ensure security.
* Updated `tempfile` dev-dependency to 3.27.0.

Version bumps:

* Bumped crate version in `Cargo.toml` and Python package version in `pyproject.toml` to 0.6.7. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)

Documentation cleanup:

* Removed the auto-generated table of contents from the `README.md` for a cleaner appearance.