### PR TITLE
Add new TypedNull class

### DIFF
--- a/fastmssql.pyi
+++ b/fastmssql.pyi
@@ -865,4 +865,34 @@ class Transaction:
         """Async context manager exit (commits or rolls back)."""
         ...
 
+class TypedNull(StrEnum):
+    """Class to store a typed null value
+
+    This is required as some SQL Server features such as stored procedures etc. sometimes require type information for which is 
+    not possible for nulls when just using `None`. In such cases, SQL Server will complain about being unable to cast 'tinyint'
+    to the desired data type.
+
+    If a TypedNull is not explicitly used, fastmssql will default to using tinyint as the 'underlying type'
+    when sending to SQL server
+    """
+
+    TINYINT = "TINYINT"
+    SMALLINT = "SMALLINT"
+    INT = "INT"
+    BIGINT = "BIGINT"
+    FLOAT32 = "FLOAT32"
+    FLOAT64 = "FLOAT64"
+    BIT = "BIT"
+    STRING = "STRING"
+    GUID = "GUID"
+    BINARY = "BINARY"
+    NUMERIC = "NUMERIC"
+    XML = "XML"
+    DATETIME = "DATETIME"
+    SMALLDATETIME = "SMALLDATETIME"
+    TIME = "TIME"
+    DATE = "DATE"
+    DATETIME2 = "DATETIME2"
+    DATETIMEOFFSET = "DATETIMEOFFSET"
+
 def version() -> str: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "fastmssql"
+name = "fastmssql-dbproj"
 version = "0.6.7"
 
 description = "A high-performance async Python library for Microsoft SQL Server built on Rust for heavy workloads and low latency."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "fastmssql-dbproj"
-version = "0.6.81"
+name = "fastmssql"
+version = "0.6.8"
 
 description = "A high-performance async Python library for Microsoft SQL Server built on Rust for heavy workloads and low latency."
 readme = "README.md"

--- a/python/fastmssql/__init__.py
+++ b/python/fastmssql/__init__.py
@@ -23,6 +23,7 @@ from .fastmssql import (
     SqlError,
     SslConfig,
     TlsError,
+    TypedNull,
     version,
 )
 from .fastmssql import (
@@ -196,5 +197,6 @@ __all__ = [
     "TlsError",
     "Transaction",
     "ApplicationIntent",
+    "TypedNull",
     "version",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub use ssl_config::{EncryptionLevel, PySslConfig};
 pub use transaction::Transaction;
 pub use types::{PyFastRow, PyQueryStream, SqlError, SqlConnectionError, TlsError, ProtocolError, ConversionError};
 
+use crate::parameter_conversion::TypedNull;
+
 #[pyfunction]
 fn version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
@@ -61,6 +63,7 @@ fn fastmssql(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<EncryptionLevel>()?;
     m.add_class::<PyAzureCredential>()?;
     m.add_class::<AzureCredentialType>()?;
+    m.add_class::<TypedNull>()?;
     
     {
         let py = m.py();

--- a/src/parameter_conversion.rs
+++ b/src/parameter_conversion.rs
@@ -7,7 +7,7 @@ use smallvec::SmallVec;
 
 #[derive(Debug, Clone)]
 pub enum FastParameter {
-    Null,
+    Null(TypedNull),
     Bool(bool),
     I64(i64),
     F64(f64),
@@ -18,7 +18,7 @@ pub enum FastParameter {
 impl tiberius::ToSql for FastParameter {
     fn to_sql(&self) -> tiberius::ColumnData<'_> {
         match self {
-            FastParameter::Null => tiberius::ColumnData::U8(None),
+            FastParameter::Null(t) => t.to_sql(),
             FastParameter::Bool(b) => b.to_sql(),
             FastParameter::I64(i) => i.to_sql(),
             FastParameter::F64(f) => f.to_sql(),
@@ -30,7 +30,12 @@ impl tiberius::ToSql for FastParameter {
 
 pub fn python_to_fast_parameter(obj: &Bound<PyAny>) -> PyResult<FastParameter> {
     if obj.is_none() {
-        return Ok(FastParameter::Null);
+        return Ok(FastParameter::Null(TypedNull::U8));
+    }
+
+    // Typed nulls
+    if let Ok(tn) = obj.extract::<TypedNull>() {
+        return Ok(FastParameter::Null(tn))
     }
 
     if let Ok(py_i) = obj.cast::<PyInt>() {
@@ -213,4 +218,124 @@ where
     }
 
     Ok(())
+}
+
+/// Class to store a typed null value
+/// 
+/// This is required as some SQL Server features such as stored procedures etc. sometimes require type information for which is 
+/// not possible for nulls when just using `None`. In such cases, SQL Server will complain about being unable to cast 'tinyint'
+/// to the desired data type.
+#[pyclass(name = "TypedNull", from_py_object)]
+#[derive(Debug, Clone)]
+pub enum TypedNull {
+    U8,
+    I16,
+    I32,
+    I64,
+    F32,
+    F64,
+    Bit,
+    String,
+    Guid,
+    Binary,
+    Numeric,
+    Xml,
+    DateTime,
+    SmallDateTime,
+    Time,
+    Date,
+    DateTime2,
+    DateTimeOffset
+}
+
+impl tiberius::ToSql for TypedNull {
+    fn to_sql(&self) -> tiberius::ColumnData<'_> {
+        match self {
+            TypedNull::U8 => tiberius::ColumnData::U8(None),
+            TypedNull::I16 => tiberius::ColumnData::I16(None),
+            TypedNull::I32 => tiberius::ColumnData::I32(None),
+            TypedNull::I64 => tiberius::ColumnData::I64(None),
+            TypedNull::F32 => tiberius::ColumnData::F32(None),
+            TypedNull::F64 => tiberius::ColumnData::F64(None),
+            TypedNull::Bit => tiberius::ColumnData::Bit(None),
+            TypedNull::String => tiberius::ColumnData::String(None),
+            TypedNull::Guid => tiberius::ColumnData::Guid(None),
+            TypedNull::Binary => tiberius::ColumnData::Binary(None),
+            TypedNull::Numeric => tiberius::ColumnData::Numeric(None),
+            TypedNull::Xml => tiberius::ColumnData::Xml(None),
+            TypedNull::DateTime => tiberius::ColumnData::DateTime(None),
+            TypedNull::SmallDateTime => tiberius::ColumnData::SmallDateTime(None),
+            TypedNull::Time => tiberius::ColumnData::Time(None),
+            TypedNull::Date => tiberius::ColumnData::Date(None),
+            TypedNull::DateTime2 => tiberius::ColumnData::DateTime2(None),
+            TypedNull::DateTimeOffset => tiberius::ColumnData::DateTimeOffset(None),
+        }
+    }
+}
+
+#[pymethods]
+impl TypedNull {
+    #[classattr]
+    const TINYINT: TypedNull = TypedNull::U8;
+    #[classattr]
+    const SMALLINT: TypedNull = TypedNull::I16;
+    #[classattr]
+    const INT: TypedNull = TypedNull::I32;
+    #[classattr]
+    const BIGINT: TypedNull = TypedNull::I64;
+    #[classattr]
+    const FLOAT32: TypedNull = TypedNull::F32;
+    #[classattr]
+    const FLOAT64: TypedNull = TypedNull::F64;
+    #[classattr]
+    const BIT: TypedNull = TypedNull::Bit;
+    #[classattr]
+    const STRING: TypedNull = TypedNull::String;
+    #[classattr]
+    const GUID: TypedNull = TypedNull::Guid;
+    #[classattr]
+    const BINARY: TypedNull = TypedNull::Binary;
+    #[classattr]
+    const NUMERIC: TypedNull = TypedNull::Numeric;
+    #[classattr]
+    const XML: TypedNull = TypedNull::Xml;
+    #[classattr]
+    const DATETIME: TypedNull = TypedNull::DateTime;
+    #[classattr]
+    const SMALLDATETIME: TypedNull = TypedNull::SmallDateTime;
+    #[classattr]
+    const TIME: TypedNull = TypedNull::Time;
+    #[classattr]
+    const DATE: TypedNull = TypedNull::Date;
+    #[classattr]
+    const DATETIME2: TypedNull = TypedNull::DateTime2;
+    #[classattr]
+    const DATETIMEOFFSET: TypedNull = TypedNull::DateTimeOffset;
+
+    pub fn __str__(&self) -> String {
+        match self {
+            TypedNull::U8 => "TINYINT".into(),
+            TypedNull::I16 => "SMALLINT".into(),
+            TypedNull::I32 => "INT".into(),
+            TypedNull::I64 => "BIGINT".into(),
+            TypedNull::F32 => "FLOAT32".into(),
+            TypedNull::F64 => "FLOAT64".into(),
+            TypedNull::Bit => "BIT".into(),
+            TypedNull::String => "STRING".into(),
+            TypedNull::Guid => "GUID".into(),
+            TypedNull::Binary => "BINARY".into(),
+            TypedNull::Numeric => "NUMERIC".into(),
+            TypedNull::Xml => "XML".into(),
+            TypedNull::DateTime => "DATETIME".into(),
+            TypedNull::SmallDateTime => "SMALLDATETIME".into(),
+            TypedNull::Time => "TIME".into(),
+            TypedNull::Date => "DATE".into(),
+            TypedNull::DateTime2 => "DATETIME2".into(),
+            TypedNull::DateTimeOffset => "DATETIMEOFFSET".into(),
+        }
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("TypedNull.{}", self.__str__())
+    }
 }

--- a/tests/test_parameter_conversions_advanced.py
+++ b/tests/test_parameter_conversions_advanced.py
@@ -12,7 +12,7 @@ import pytest
 from conftest import Config
 
 try:
-    from fastmssql import Connection
+    from fastmssql import Connection, Transaction, TypedNull
 except ImportError:
     pytest.fail("fastmssql not available - run 'maturin develop' first")
 
@@ -432,5 +432,27 @@ async def test_parameter_type_explicit_casting(test_config: Config):
             value = result.rows()[0]["value"]
             if value is not None:
                 assert abs(float(value) - 3.14) < 0.1
+    except Exception as e:
+        pytest.fail(f"Database not available: {e}")
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_parameter_typed_null(test_config: Config):
+    """Test explicit type casting in queries."""
+    try:
+        async with Transaction(test_config.connection_string) as tx:
+            # Create test stored procedure
+            await tx.execute("CREATE OR ALTER PROCEDURE test_proc (@dt date) AS BEGIN; THROW 56000, 'ok', 0 END")
+
+            # This should fail
+            try:
+                await tx.execute("EXECUTE test_proc @P1", None)
+            except Exception as e:
+                assert "tinyint" in str(e) and "date" in str(e)
+
+            # Should work
+            await tx.execute("EXECUTE test_proc @P1", TypedNull.DATE)
+            
+            await tx.rollback()
     except Exception as e:
         pytest.fail(f"Database not available: {e}")

--- a/tests/test_parameter_conversions_advanced.py
+++ b/tests/test_parameter_conversions_advanced.py
@@ -446,12 +446,12 @@ async def test_parameter_typed_null(test_config: Config):
 
             # This should fail
             try:
-                await tx.execute("EXECUTE test_proc @P1", None)
+                await tx.execute("EXECUTE test_proc @P1", [None])
             except Exception as e:
                 assert "tinyint" in str(e) and "date" in str(e)
 
             # Should work
-            await tx.execute("EXECUTE test_proc @P1", TypedNull.DATE)
+            await tx.execute("EXECUTE test_proc @P1", [TypedNull.DATE])
             
             await tx.rollback()
     except Exception as e:

--- a/tests/test_parameter_conversions_advanced.py
+++ b/tests/test_parameter_conversions_advanced.py
@@ -12,7 +12,7 @@ import pytest
 from conftest import Config
 
 try:
-    from fastmssql import Connection, Transaction, TypedNull
+    from fastmssql import Connection, Transaction, TypedNull, SqlError
 except ImportError:
     pytest.fail("fastmssql not available - run 'maturin develop' first")
 
@@ -450,9 +450,12 @@ async def test_parameter_typed_null(test_config: Config):
             except Exception as e:
                 assert "tinyint" in str(e) and "date" in str(e)
 
-            # Should work
-            await tx.execute("EXECUTE test_proc @P1", [TypedNull.DATE])
-            
+            # Should work with a code of 56000
+            try:
+                await tx.execute("EXECUTE test_proc @P1", [TypedNull.DATE])
+            except SqlError as e:
+                assert e.code == 56000
+
             await tx.rollback()
     except Exception as e:
         pytest.fail(f"Database not available: {e}")

--- a/tests/test_parameter_conversions_advanced.py
+++ b/tests/test_parameter_conversions_advanced.py
@@ -12,7 +12,7 @@ import pytest
 from conftest import Config
 
 try:
-    from fastmssql import Connection, Transaction, TypedNull, SqlError
+    from fastmssql import Connection, TypedNull
 except ImportError:
     pytest.fail("fastmssql not available - run 'maturin develop' first")
 
@@ -438,32 +438,20 @@ async def test_parameter_type_explicit_casting(test_config: Config):
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_parameter_typed_null(test_config: Config):
-    """Test explicit type casting in queries."""
+    """Test explicit typed nulls in queries (unfortunately cant use stored procedures here)."""
     try:
-        async with Transaction(test_config.connection_string) as tx:
-            # Create test stored procedure
+        async with Connection(test_config.connection_string) as conn:
+            # This should yield NULL (1 + tinyint of null)
+            res = await conn.query("SELECT 1 + @P1 as value", [None])
+            value = res.rows()[0]["value"]
+            assert value is None
+
+            err = None
             try:
-                await tx.execute("CREATE PROCEDURE test_proc (@dt date) AS BEGIN; THROW 56000, 'ok', 0 END")
+                res = await conn.query("SELECT 1 + @P1 as value", [TypedNull.DATE])
             except Exception as e:
-                if "Incorrect syntax near the keyword 'PROCEDURE'" in str(e):
-                    pytest.skip(
-                        "Stored procedures not supported in this SQL Server edition"
-                    )
-                else:
-                    raise
+                err = str(e)
+            assert err is not None and "date is incompatible with int" in err
 
-            # This should fail
-            try:
-                await tx.execute("EXECUTE test_proc @P1", [None])
-            except Exception as e:
-                assert "tinyint" in str(e) and "date" in str(e)
-
-            # Should work with a code of 56000
-            try:
-                await tx.execute("EXECUTE test_proc @P1", [TypedNull.DATE])
-            except SqlError as e:
-                assert e.code == 56000
-
-            await tx.rollback()
     except Exception as e:
         pytest.fail(f"Database not available: {e}")

--- a/tests/test_parameter_conversions_advanced.py
+++ b/tests/test_parameter_conversions_advanced.py
@@ -442,7 +442,15 @@ async def test_parameter_typed_null(test_config: Config):
     try:
         async with Transaction(test_config.connection_string) as tx:
             # Create test stored procedure
-            await tx.execute("CREATE OR ALTER PROCEDURE test_proc (@dt date) AS BEGIN; THROW 56000, 'ok', 0 END")
+            try:
+                await tx.execute("CREATE PROCEDURE test_proc (@dt date) AS BEGIN; THROW 56000, 'ok', 0 END")
+            except Exception as e:
+                if "Incorrect syntax near the keyword 'PROCEDURE'" in str(e):
+                    pytest.skip(
+                        "Stored procedures not supported in this SQL Server edition"
+                    )
+                else:
+                    raise
 
             # This should fail
             try:


### PR DESCRIPTION
Sometimes, SQL server needs complete type info for even NULLs (such as when executing stored procedures) which, with fastmssql, is not possible for nulls (as they are just `None`). In such cases, SQL Server will complain about being unable to cast 'tinyint' to the desired data type as fastmssql uses ``tiberius::ColumnData::U8(None)`` for `None`.

This PR introduces the TypedNull enum that enables users to provide fastmssql with type information for null values which is then propagated into picking the right tiberius::ColumnData variant.